### PR TITLE
Add get-report and list-reports features

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,29 +1,73 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"vmuser/config"
-	"vmuser/database"
-	"vmuser/pkg/reports"
+        "context"
+        "database/sql"
+        "fmt"
+        "os"
+        "text/tabwriter"
+        "vmuser/config"
+        "vmuser/database"
+        "vmuser/pkg/reports"
 )
 
 func AddReport(ctx context.Context, cfg *config.VMUserConfig, filePath string) error {
-	// Check if file exists
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return fmt.Errorf("report file does not exist: %s", filePath)
-	}
+        // Check if file exists
+        if _, err := os.Stat(filePath); os.IsNotExist(err) {
+                return fmt.Errorf("report file does not exist: %s", filePath)
+        }
 
-	db, err := database.GetConnection(&cfg.Turso)
-	if err != nil {
-		return fmt.Errorf("error getting database connection: %w", err)
-	}
+        db, err := database.GetConnection(&cfg.Turso)
+        if err != nil {
+                return fmt.Errorf("error getting database connection: %w", err)
+        }
 
-	err = reports.AddReportToDatabase(ctx, db, filePath)
-	if err != nil {
-		return fmt.Errorf("error adding report to database: %w", err)
-	}
+        err = reports.AddReportToDatabase(ctx, db, filePath)
+        if err != nil {
+                return fmt.Errorf("error adding report to database: %w", err)
+        }
 
-	return nil
+        return nil
+}
+
+// GetReportByID retrieves a specific report by its ID
+func GetReportByID(ctx context.Context, cfg *config.VMUserConfig, id int64) (*reports.Report, error) {
+        db, err := database.GetConnection(&cfg.Turso)
+        if err != nil {
+                return nil, fmt.Errorf("error getting database connection: %w", err)
+        }
+
+        report, err := reports.GetReport(ctx, db, id)
+        if err != nil {
+                if err == sql.ErrNoRows {
+                        return nil, fmt.Errorf("report with ID %d not found", id)
+                }
+                return nil, fmt.Errorf("error retrieving report: %w", err)
+        }
+
+        return report, nil
+}
+
+// ListAllReports retrieves all reports from the database
+func ListAllReports(ctx context.Context, cfg *config.VMUserConfig) ([]reports.Report, error) {
+        db, err := database.GetConnection(&cfg.Turso)
+        if err != nil {
+                return nil, fmt.Errorf("error getting database connection: %w", err)
+        }
+
+        reportList, err := reports.ListReports(ctx, db)
+        if err != nil {
+                return nil, fmt.Errorf("error retrieving reports: %w", err)
+        }
+
+        return reportList, nil
+}
+
+// DisplayReport formats and prints a single report
+func DisplayReport(w *tabwriter.Writer, report *reports.Report) {
+        fmt.Fprintf(w, "Report ID:\t%d\n", report.ID)
+        fmt.Fprintf(w, "Filename:\t%s\n", report.Filename)
+        fmt.Fprintf(w, "Created At:\t%s\n", report.CreatedAt.Format("2006-01-02 15:04:05"))
+        fmt.Fprintf(w, "Updated At:\t%s\n", report.UpdatedAt.Format("2006-01-02 15:04:05"))
+        fmt.Fprintf(w, "Content:\n%s\n", report.Content)
 }

--- a/docs/get-report-feature.md
+++ b/docs/get-report-feature.md
@@ -1,0 +1,65 @@
+# Get Report Feature Design
+
+## Overview
+Add functionality to retrieve reports from the database, both individual reports by ID and listing all reports.
+
+## Current State
+- The database layer already has `GetReport` and `ListReports` functions implemented
+- The CLI only exposes the `add-report` functionality
+- Reports are stored with content, filename, and timestamps
+
+## Implementation Plan
+
+### 1. Command Line Interface
+Add two new commands:
+- `vmuser get-report <id>`: Retrieve a specific report by ID
+- `vmuser list-reports`: List all available reports
+
+### 2. Command Layer Implementation
+Create new functions in `cmd/report.go`:
+
+```go
+func GetReportByID(ctx context.Context, cfg *config.VMUserConfig, id int64) (*reports.Report, error)
+func ListAllReports(ctx context.Context, cfg *config.VMUserConfig) ([]reports.Report, error)
+```
+
+### 3. Output Formatting
+For `get-report`:
+- Display report ID, filename, and content
+- Show creation and update timestamps
+- Option to save content to a file
+
+For `list-reports`:
+- Display a table with columns: ID, Filename, Created At
+- Omit content for brevity
+- Sort by creation date (newest first)
+
+### 4. Error Handling
+- Handle "report not found" scenarios
+- Validate input ID format
+- Handle database connection errors
+- Provide user-friendly error messages
+
+### 5. Testing
+- Add unit tests for new command functions
+- Add integration tests with the database
+- Test edge cases (invalid IDs, empty database)
+
+## Usage Examples
+
+```bash
+# Get a specific report
+vmuser get-report 123
+
+# List all reports
+vmuser list-reports
+
+# Get a report and save to file
+vmuser get-report 123 --output report.txt
+```
+
+## Future Enhancements
+- Add filtering options for list-reports (by date range, filename)
+- Add search functionality
+- Add output format options (JSON, CSV)
+- Add pagination for list-reports

--- a/main.go
+++ b/main.go
@@ -1,46 +1,81 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"log/slog"
-	"os"
-	"os/signal"
-	"syscall"
-	"vmuser/cmd"
-	"vmuser/config"
+        "context"
+        "flag"
+        "fmt"
+        "log/slog"
+        "os"
+        "os/signal"
+        "syscall"
+        "text/tabwriter"
+        "vmuser/cmd"
+        "vmuser/config"
 )
 
 func main() {
-	configFile := flag.String("config", "vmuser.toml", "Path to the configuration file")
-	tui := flag.Bool("tui", false, "Run TUI")
-	addReport := flag.String("add-report", "", "Path to the report file to add")
+        configFile := flag.String("config", "vmuser.toml", "Path to the configuration file")
+        tui := flag.Bool("tui", false, "Run TUI")
+        addReport := flag.String("add-report", "", "Path to the report file to add")
+        getReport := flag.Int64("get-report", -1, "ID of the report to retrieve")
+        listReports := flag.Bool("list-reports", false, "List all reports")
 
-	flag.Parse()
+        flag.Parse()
 
-	appContext, stop := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill, syscall.SIGTERM)
-	defer stop()
+        appContext, stop := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill, syscall.SIGTERM)
+        defer stop()
 
-	cfg := config.GetVMUserConfig(*configFile)
+        cfg := config.GetVMUserConfig(*configFile)
 
-	// Handle add-report command first
-	if *addReport != "" {
-		if err := cmd.AddReport(appContext, cfg, *addReport); err != nil {
-			slog.Error("Error adding report", "error", err, "file", *addReport)
-			os.Exit(1)
-		}
-		return
-	}
+        // Handle report commands
+        if *addReport != "" {
+                if err := cmd.AddReport(appContext, cfg, *addReport); err != nil {
+                        slog.Error("Error adding report", "error", err, "file", *addReport)
+                        os.Exit(1)
+                }
+                return
+        }
 
-	if *tui {
-		if err := cmd.TUI(appContext, cfg); err != nil {
-			slog.Error("Error running application", "error", err)
-			os.Exit(1)
-		}
-	}
+        if *getReport >= 0 {
+                report, err := cmd.GetReportByID(appContext, cfg, *getReport)
+                if err != nil {
+                        slog.Error("Error getting report", "error", err, "id", *getReport)
+                        os.Exit(1)
+                }
+                w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+                cmd.DisplayReport(w, report)
+                w.Flush()
+                return
+        }
 
-	if err := cmd.Server(appContext, cfg); err != nil {
-		slog.Error("Error running application", "error", err)
-		os.Exit(1)
-	}
+        if *listReports {
+                reports, err := cmd.ListAllReports(appContext, cfg)
+                if err != nil {
+                        slog.Error("Error listing reports", "error", err)
+                        os.Exit(1)
+                }
+                w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+                fmt.Fprintln(w, "ID\tFilename\tCreated At")
+                fmt.Fprintln(w, "---\t--------\t----------")
+                for _, r := range reports {
+                        fmt.Fprintf(w, "%d\t%s\t%s\n",
+                                r.ID,
+                                r.Filename,
+                                r.CreatedAt.Format("2006-01-02 15:04:05"))
+                }
+                w.Flush()
+                return
+        }
+
+        if *tui {
+                if err := cmd.TUI(appContext, cfg); err != nil {
+                        slog.Error("Error running application", "error", err)
+                        os.Exit(1)
+                }
+        }
+
+        if err := cmd.Server(appContext, cfg); err != nil {
+                slog.Error("Error running application", "error", err)
+                os.Exit(1)
+        }
 }

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,12 @@ go run . --tui
 # Add a report
 go run . --add-report path/to/report.md
 
+# Get a specific report by ID
+go run . --get-report 123
+
+# List all reports
+go run . --list-reports
+
 # Specify config file
 go run . --config custom_config.toml
 ```


### PR DESCRIPTION
This PR adds two new features to the vmuser CLI:
- `--get-report <id>`: Retrieve a specific report by ID
- `--list-reports`: List all available reports

Changes include:
- New report retrieval functions in cmd/report.go
- CLI command integration in main.go
- Design documentation
- Updated readme with new commands

This builds upon the existing database functionality and provides a complete reporting solution alongside the existing add-report feature.